### PR TITLE
added verify route and verification reminder

### DIFF
--- a/stormpiper/stormpiper/spa/src/App.css
+++ b/stormpiper/stormpiper/spa/src/App.css
@@ -130,6 +130,36 @@
   background: rgba(255, 255, 255, 1);
   border-radius: 2px;
 }
+#verification-panel {
+	position: fixed;
+	z-index: 9;
+	top: 30%;
+  left: 25%;
+  overflow-x: hidden;
+  overflow-y: auto;
+  height: auto;
+  width: 50%;
+  text-align:center;
+  /* background: rgba(255, 255, 255, 1); */
+  /* border-radius: 2px; */
+
+}
+
+#verification-panel-hidden{
+  /* transition-property: height,width,left;
+  transition-duration: 500ms; */
+  position: fixed;
+	z-index: 9;
+	top: 30%;
+  left: -50%;
+  /* left: 125%; */
+  overflow-x: hidden;
+  overflow-y: hidden;
+  height:5%;
+  width: 3%;
+  background: rgba(255, 255, 255, 1);
+  border-radius: 2px;
+}
 #results-panel {
   transition-property: top;
   transition-timing-function: linear;

--- a/stormpiper/stormpiper/spa/src/components/authProvider.tsx
+++ b/stormpiper/stormpiper/spa/src/components/authProvider.tsx
@@ -3,15 +3,9 @@ import { useNavigate } from "react-router-dom";
 
 export default function AuthProvider(props: any) {
   const navigate = useNavigate();
-  let baseURL = import.meta.env.BASE_URL.toString().split("/");
-  baseURL.pop();
-  baseURL.pop();
-  const revisedURL = baseURL.length > 1 ? baseURL.join("/") : "/";
-  
-
 
   useEffect(() => {
-    fetch(revisedURL + "api/rest/users/me")
+    fetch("/api/rest/users/me")
       .then((res) => {
         return res.json();
       })

--- a/stormpiper/stormpiper/spa/src/components/verify.tsx
+++ b/stormpiper/stormpiper/spa/src/components/verify.tsx
@@ -1,0 +1,87 @@
+import { useSearchParams,useNavigate } from "react-router-dom"
+import React, {useEffect, useState} from "react";
+import { Card, CardContent, Typography } from "@material-ui/core";
+
+export default function Verify(){
+
+    const [searchParams, setSearchParams] = useSearchParams()
+    const navigate = useNavigate()
+
+    let token:string|null = searchParams.get('token')
+    let expiresAt:string|null = searchParams.get('expires_at')
+    let now = new Date()
+    let expiryDateFormatted = new Date(expiresAt?.split(' ')[0])
+    console.log("Token:",token)
+    console.log("expires_at: ",expiryDateFormatted)
+
+    const [verifyResults,setVerifyResults] = useState((
+      <React.Fragment>
+          <Typography variant="subtitle1">
+            Checking your verification status...
+          </Typography>
+        </React.Fragment>
+    ))
+
+    useEffect(()=>{
+      if(now>expiryDateFormatted){
+        setVerifyResults(
+          <React.Fragment>
+            <Typography variant="subtitle1">
+              Sorry, your email verification link has expired
+            </Typography>
+            <Typography variant="subtitle2">
+              Please <a href="javascript:;" onClick={()=>navigate('/app/login')}>log in </a> again to request another link
+            </Typography>
+          </React.Fragment>
+        )
+      }
+      else{
+        fetch('/auth/verify',{
+          headers: {
+            Accept: "application/json",
+            "Content-Type": "application/json",
+          },
+          method: "POST",
+          body: JSON.stringify({"token":token}),
+        }).then(resp=>{
+          console.log("Auth response: ",resp.status)
+          if(resp.status===200){
+            setVerifyResults(
+              <React.Fragment>
+                <Typography variant="subtitle1">
+                  Thank you for verifying your email with Tacoma Watershed Insights
+                </Typography>
+                <Typography variant="subtitle2">
+                  Please <a href="javascript:;" onClick={()=>navigate('/app/login')}>log in </a> with the credentials you created for your account
+                </Typography>
+              </React.Fragment>
+            )
+          }else{
+            setVerifyResults(
+            <React.Fragment>
+            <Typography variant="subtitle1">
+              Sorry, something went wrong with your verification
+            </Typography>
+            <Typography variant="subtitle2">
+              Please <a href="javascript:;" onClick={()=>navigate('/app/login')}>log in </a> again to request another link
+            </Typography>
+          </React.Fragment>
+            )
+          }
+        })
+      }
+    },[])
+
+
+   return (
+            <div className="flex-row">
+              <div className="lg-margin">
+                <Card>
+                  <CardContent>
+                    {verifyResults}
+                  </CardContent>
+                </Card>
+              </div>
+            </div>
+        );
+}

--- a/stormpiper/stormpiper/spa/src/index.jsx
+++ b/stormpiper/stormpiper/spa/src/index.jsx
@@ -5,6 +5,7 @@ import "./index.css";
 import App from "./App";
 import Login from "./components/login"
 import Register from "./components/register"
+import Verify from "./components/verify";
 // import reportWebVitals from './reportWebVitals';
 
 ReactDOM.render(
@@ -12,8 +13,9 @@ ReactDOM.render(
     <BrowserRouter>
       <Routes>
         <Route path="/app/" element={<App/>}></Route>
-        <Route path="app/login/" element={<Login/>}></Route>
-        <Route path="app/register/" element={<Register/>}></Route>
+        <Route path="/app/login/" element={<Login/>}></Route>
+        <Route path="/app/register/" element={<Register/>}></Route>
+        <Route path="/app/verify/" element={<Verify/>}></Route>
         <Route path="/app/map/" element={<App/>}>
           <Route path="tmnt" element={<App/>}>
             <Route path=":id" element = {<App/>}></Route>


### PR DESCRIPTION
`app/verify` now serves the results of what happens when the user clicks on their verification email link. It accepts a 'token' and 'expires_at' query parameter to pass onto the `auth/verify` and to check whether the verification link has expired 

The main app component now checks whether the user is verified. If not, a pop-up appears to remind them that they should verify, and provides a link to request a new token if it's expired