### PR TITLE
Add password reset

### DIFF
--- a/stormpiper/stormpiper/spa/src/App.css
+++ b/stormpiper/stormpiper/spa/src/App.css
@@ -1,17 +1,8 @@
-/* .App {
-  text-align: center;
-} */
 
 .App-logo {
   height: 40vmin;
   pointer-events: none;
 }
-
-/* @media (prefers-reduced-motion: no-preference) {
-  .App-logo {
-    animation: App-logo-spin infinite 20s linear;
-  }
-} */
 
 .App-header {
   background-color: #282c34;
@@ -27,15 +18,6 @@
 .App-link {
   color: #61dafb;
 }
-
-/* @keyframes App-logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
-} */
 
 #header-panel{
   position: fixed;
@@ -77,10 +59,6 @@
   border-radius: 2px;
 
 }
-
-/* #control-panel > div{
-	padding: 0 20px 20px 20px;
-} */
 
 .layer-controls {
 	border: groove 2px #fff;
@@ -197,6 +175,10 @@
   padding:0px !important;
 }
 
+.zero-margin{
+  margin:0px !important;
+}
+
 .lg-margin{
   margin:5em;
 }
@@ -212,4 +194,64 @@
   align-content: center;
   flex-wrap:wrap;
   align-items:center;
+}
+
+
+/* Authentication Form Styles (reset, verify, forgot, login, register) */
+.flex{
+  display:flex;
+  justify-content: center;
+  flex-wrap:wrap;
+}
+
+.auth-form{
+  width:100%;
+  height:50%;
+}
+
+.auth-form-body{
+  width:30%;
+  height:auto;
+  display:flex;
+  flex-wrap:wrap;
+  justify-content: center;
+  background:rgba(249, 247, 247, 0.8);
+  margin:50px;
+  padding:10px;
+}
+
+.form-label{
+  font-size: 10px;
+  margin: 5px 20px;
+}
+
+.required::after{
+  content:"*";
+  color: red;
+}
+
+.form-input{
+  margin: 5px 20px;
+  width:90%;
+}
+
+.auth-form-row{
+  text-align:start;
+  width:100%;
+}
+
+.result-header, .err-list-header{
+  padding: 0em 1em;
+}
+
+.err-msg{
+  color:red
+}
+
+/* input .auth{
+  width:50%
+} */
+
+.auth-button-bar{
+  padding: 10px 0px;
 }

--- a/stormpiper/stormpiper/spa/src/App.jsx
+++ b/stormpiper/stormpiper/spa/src/App.jsx
@@ -57,7 +57,6 @@ function App() {
         return res.json();
       })
       .then((res) => {
-        console.log("User Response?:",res['is_verified'])
         setUserEmail(res.email)
         if(!res['is_verified]']){
           setVerificationDisplayState(true)

--- a/stormpiper/stormpiper/spa/src/App.jsx
+++ b/stormpiper/stormpiper/spa/src/App.jsx
@@ -58,33 +58,33 @@ function App() {
       })
       .then((res) => {
         setUserEmail(res.email)
-        if(!res['is_verified]']){
+        if(!res['is_verified']){
           setVerificationDisplayState(true)
         }
       });
   },[])
 
   const topMenuButtons={
-    home:{
-      label:"Home",
-      icon:<HomeRoundedIcon/>,
-      clickHandler:null
-    },
+    // home:{
+    //   label:"Home",
+    //   icon:<HomeRoundedIcon/>,
+    //   clickHandler:null
+    // },
     project:{
       label:"Evaluate Project",
       icon:<ScatterPlotRoundedIcon/>,
       clickHandler:_toggleSetResultsDisplayState
     },
-    watershed:{
-      label:"Evaluate Watershed",
-      icon:<GridOnRoundedIcon/>,
-      clickHandler:null
-    },
-    about:{
-      label:"About",
-      icon:<InfoRoundedIcon/>,
-      clickHandler:null
-    }
+    // watershed:{
+    //   label:"Evaluate Watershed",
+    //   icon:<GridOnRoundedIcon/>,
+    //   clickHandler:null
+    // },
+    // about:{
+    //   label:"About",
+    //   icon:<InfoRoundedIcon/>,
+    //   clickHandler:null
+    // }
   }
 
 

--- a/stormpiper/stormpiper/spa/src/assets/geojson/coreLayers.js
+++ b/stormpiper/stormpiper/spa/src/assets/geojson/coreLayers.js
@@ -221,7 +221,7 @@ const delineations = {
     getElevation: (f) => 500,
     lineWidthScale: 2,
     lineWidthMinPixels: 1,
-    pickable: false,
+    pickable: true,
     // onClick:(info,event)=>console.log(info,event),
     highlightColor:[42,213,232],
     dashJustified: true,
@@ -265,6 +265,7 @@ const tssRaster = {
     minZoom: 10,
     maxZoom: 18,
     tileSize: 256,
+
     renderSubLayers: (props) => {
       const {
         bbox: { west, south, east, north },
@@ -326,26 +327,18 @@ const clusteredPopRaster = {
 
 /* eslint-disable quote-props */
 export const layerDict = {
-  "Surfacewater": {
-    "Active Network":[
-      delineations,
-      // activeSWMain,
-      activeLocalSWFacility
-    ],
-    // "Proposed Network":[proposedSWFacility]
-  },
-  // "Wastewater": {
-  //   "Active Network":[activeWWMain],
-  // },
-  // "Municipal Characteristics":{
-  //   "Infrastructure Characteristics":[capitalProjectStreets,row],
-  //   "General Characteristics":[landUseDesignations,equalOpportunityIndex],
-  // },
   "Base Imagery": {
     "Raster":[
       tssRaster,
       // landCoverRaster,
       // clusteredPopRaster
     ]
-  }
+  },
+  "Surfacewater": {
+    "Active Network":[
+      delineations,
+      // activeSWMain,
+      activeLocalSWFacility
+    ],
+  },
 };

--- a/stormpiper/stormpiper/spa/src/components/bmpStatWindow.tsx
+++ b/stormpiper/stormpiper/spa/src/components/bmpStatWindow.tsx
@@ -17,14 +17,14 @@ const statsDict={
     label:"Design Parameters",
     fields:["design_storm_depth_inches","total_volume_cuft","retention_volume_cuft"],
   },
-  tributaryArea:{
-    label:"Tributary Area",
-    fields:["tributary_area_tc_min"],
-  },
-  lifeCycleCosts:{
-    label:"Life-Cycle Costs",
-    fields:[],
-  },
+  // tributaryArea:{
+  //   label:"Tributary Area",
+  //   fields:["tributary_area_tc_min"],
+  // },
+  // lifeCycleCosts:{
+  //   label:"Life-Cycle Costs",
+  //   fields:[],
+  // },
   performanceSummary:{
     label:"Performance Summary",
     fields:["runoff_volume_cuft_inflow","runoff_volume_cuft_treated","runoff_volume_cuft_retained","runoff_volume_cuft_captured","runoff_volume_cuft_bypassed"],

--- a/stormpiper/stormpiper/spa/src/components/forgot.tsx
+++ b/stormpiper/stormpiper/spa/src/components/forgot.tsx
@@ -1,9 +1,14 @@
 import React, { useState } from "react";
 import { useNavigate,useSearchParams } from "react-router-dom"
 import { useForm } from "react-hook-form";
-// import "./reset.css"
-import { Typography,TextField,Button, CardContent, Card, Box } from "@material-ui/core";
+import { Typography,TextField,Button, CardContent, Card, Box, makeStyles } from "@material-ui/core";
 
+const useStyles = makeStyles((theme)=>({
+    errorMsg:{
+      color:theme.palette.warning.main,
+      margin:'5px 20px'
+    }
+}))
 
 export default function Forgot(){
     const navigate = useNavigate()
@@ -11,6 +16,7 @@ export default function Forgot(){
     const [error,setError] = useState(false)
     const [success,setSuccess] = useState(false)
     const [searchParams, setSearchParams] = useSearchParams()
+    const classes = useStyles()
 
     const fields: {
       name: string;
@@ -38,7 +44,7 @@ export default function Forgot(){
                     {
                         <TextField  {...register(formField.name,{...formField})} label = {formField.label} type = {formField.type} required={formField.required}/>
                     }
-                    {errors[formField.name] && <p className="form-label error-msg">{errors[formField.name]?.message}</p>}
+                    {errors[formField.name] && <Typography variant='caption' className={classes.errorMsg} align='center'>{errors[formField.name]?.message}</Typography>}
                 </div>
 
             )
@@ -72,11 +78,8 @@ export default function Forgot(){
 
 
     return (
-        // <div className="auth-container">
-        //     <div className="auth-form flex">
         <div className="flex-row">
             <div className="flex lg-margin">
-            {/* <div className="auth-form-body flex"> */}
                 <Card>
                     <CardContent>
                         <Typography variant="subtitle1" align="center"> Welcome to the Tacoma Watershed Insights Tool</Typography>
@@ -86,20 +89,19 @@ export default function Forgot(){
                             {_renderFormFields()}
                             <div className="auth-button-bar flex">
                                 <Button variant="contained" type = "submit">Submit</Button>
+                                {
+                                    error && <Typography variant='caption' className={classes.errorMsg} align='center'>Reset request failed - please try again</Typography>
+                                }
+                                {
+                                    success && <Typography variant='caption' className={classes.errorMsg} align='center'>A reset link was sent to the email associated with this account - Use the link to reset your email, and return to <a href="javascript:;" onClick={()=>navigate('/app/login')}>Login</a></Typography>
+                                }
                             </div>
-                            {
-                                error && <p className="err-msg">Something went wrong - please try again</p>
-                            }
-                            {
-                                success && <p className="success-msg">A reset link was sent to the email associated with this account - Use the link to reset your email, and return to <a href="javascript:;" onClick={()=>navigate('/app/login')}>Login</a></p>
-                            }
                             </form>
                         </Box>
                     </CardContent>
                 </Card>
             </div>
         </div>
-        // </div>
         );
 }
 

--- a/stormpiper/stormpiper/spa/src/components/forgot.tsx
+++ b/stormpiper/stormpiper/spa/src/components/forgot.tsx
@@ -1,0 +1,107 @@
+import React, { useState } from "react";
+import { useNavigate,useSearchParams } from "react-router-dom"
+import { useForm } from "react-hook-form";
+// import "./reset.css"
+import { Typography,TextField,Button, CardContent, Card, Box } from "@material-ui/core";
+
+
+export default function Forgot(){
+    const navigate = useNavigate()
+    const {register,handleSubmit,formState: { errors },getValues} = useForm()
+    const [error,setError] = useState(false)
+    const [success,setSuccess] = useState(false)
+    const [searchParams, setSearchParams] = useSearchParams()
+
+    const fields: {
+      name: string;
+      label: string;
+      type: string;
+      required?: boolean;
+      defaultValue: string | number | null;
+      minLength?: { value: number; message: string };
+      maxLength?: { value: number; message: string };
+      validate?: (val: any) => boolean | string;
+    }[] = [
+      {
+        name: "username",
+        label: "username",
+        type: "email",
+        required: true,
+        defaultValue: "",
+      },
+    ];
+
+    function _renderFormFields(){
+        let fieldDiv = Object.values(fields).map((formField)=>{
+          return (
+                <div className="flex auth-form-row">
+                    {
+                        <TextField  {...register(formField.name,{...formField})} label = {formField.label} type = {formField.type} required={formField.required}/>
+                    }
+                    {errors[formField.name] && <p className="form-label error-msg">{errors[formField.name]?.message}</p>}
+                </div>
+
+            )
+        })
+        return fieldDiv;
+
+    }
+
+
+    async function _handleSubmit() {
+        const response = await fetch("/auth/forgot-password", {
+        credentials: "same-origin",
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ email: getValues().username }),
+        }).then((resp) => {
+        if (resp.status == 202) {
+            setError(false);
+            setSuccess(true)
+        } else {
+            console.warn("login failure", resp);
+            setError(true);
+            setSuccess(false)
+        }
+        });
+        return response;
+    }
+
+
+
+    return (
+        // <div className="auth-container">
+        //     <div className="auth-form flex">
+        <div className="flex-row">
+            <div className="flex lg-margin">
+            {/* <div className="auth-form-body flex"> */}
+                <Card>
+                    <CardContent>
+                        <Typography variant="subtitle1" align="center"> Welcome to the Tacoma Watershed Insights Tool</Typography>
+                        <Typography variant="subtitle2" align="center"> Enter the email associated with your account below to reset your password</Typography>
+                        <Box sx={{margin:'1em'}}>
+                            <form onSubmit={handleSubmit(_handleSubmit)}>
+                            {_renderFormFields()}
+                            <div className="auth-button-bar flex">
+                                <Button variant="contained" type = "submit">Submit</Button>
+                            </div>
+                            {
+                                error && <p className="err-msg">Something went wrong - please try again</p>
+                            }
+                            {
+                                success && <p className="success-msg">A reset link was sent to the email associated with this account - Use the link to reset your email, and return to <a href="javascript:;" onClick={()=>navigate('/app/login')}>Login</a></p>
+                            }
+                            </form>
+                        </Box>
+                    </CardContent>
+                </Card>
+            </div>
+        </div>
+        // </div>
+        );
+}
+
+
+

--- a/stormpiper/stormpiper/spa/src/components/login.css
+++ b/stormpiper/stormpiper/spa/src/components/login.css
@@ -31,7 +31,6 @@
 }
 
 .form-input{
-    /* max-width: 50px; */
     margin: 5px 20px;
     width:80%;
 }
@@ -39,13 +38,6 @@
 .login-form-row{
     text-align:start;
     width:100%;
-}
-
-.login-header{
-    font-size:medium
-}
-.login-sub-header{
-    font-size:small
 }
 
 .result-header, .err-list-header{
@@ -56,9 +48,9 @@
     color:red
 }
 
-input .login{
+/* input .login{
     width:50%
-}
+} */
 
 .login-button-bar{
     padding: 10px 0px;

--- a/stormpiper/stormpiper/spa/src/components/login.tsx
+++ b/stormpiper/stormpiper/spa/src/components/login.tsx
@@ -1,13 +1,13 @@
 import React, { useState } from "react";
 import { useNavigate } from "react-router-dom"
 import { useForm } from "react-hook-form";
-import "./login.css"
-import { Typography } from "@material-ui/core";
+// import "./login.css"
+import { Box, Card, CardContent, Typography } from "@material-ui/core";
 import { TextField,Input,Button } from '@material-ui/core'
 
 export default function Login(){
     const navigate = useNavigate()
-    const {register,handleSubmit} = useForm()
+    const {register,handleSubmit, getValues} = useForm()
     const [error,setError] = useState(false)
 
     const fields:{fieldID:string,label:string,type:string,required:boolean,value:string|number}[] = [
@@ -30,11 +30,7 @@ export default function Login(){
     function _renderFormFields(){
         let fieldDiv = Object.values(fields).map((formField:{fieldID:string,label:string,type:string,required:boolean,value:string|number})=>{
           return (
-                <div className="flex login-form-row">
-                    {/* {formField.required
-                      ?<InputLabel className="form-label required" htmlFor={formField.fieldID}>{formField.label}</InputLabel>
-                      :<InputLabel className="form-label" htmlFor={formField.fieldID}>{formField.label}</InputLabel>
-                    } */}
+                <div className="flex auth-form-row">
                     {
                         <TextField  {...register(formField.fieldID)} label = {formField.label} type = {formField.type} defaultValue={formField.value} required={formField.required}/>
                     }
@@ -68,29 +64,32 @@ export default function Login(){
 
 
 
+
     return (
-      <div className="login-container">
-        <div className="login-form flex">
-          <div className="login-form-body flex">
-            <div className="flex">
-            <Typography className="login-header" variant="subtitle1"> Welcome to the Tacoma Watershed Insights Tool</Typography>
-            <Typography className="login-sub-header" variant="subtitle2"> Login or <a href="javascript:;" onClick={()=>navigate('/app/register')}>Register</a> to get Started</Typography>
-            </div>
-            <form className="flex" onSubmit={handleSubmit(_handleSubmit)}>
-              {_renderFormFields()}
-              {/* <div className="reset-container">
-                <a className="form-label" href="javascript:;" onClick={()=>navigate('/app/reset')}>Forgot your password?</a>
-              </div> */}
-              <div className="login-button-bar">
-                <Button variant="contained" type = "submit">Submit</Button>
-              </div>
-              {
-                error
-                  ?<p className="err-msg">Incorrect username/password - please try again</p>
-                  :<p></p>
-              }
-            </form>
-          </div>
+      <div className="flex-row">
+        <div className="flex lg-margin">
+          <Card>
+            <CardContent>
+              <Typography variant="subtitle1" align="center"> Welcome to the Tacoma Watershed Insights Tool</Typography>
+              <Typography variant="subtitle2" align="center"> Login or <a href="javascript:;" onClick={()=>navigate('/app/register')}>Register</a> to get Started</Typography>
+              <Box sx={{margin:'1em'}}>
+                <form className="flex" onSubmit={handleSubmit(_handleSubmit)}>
+                  {_renderFormFields()}
+                  <div className="flex auth-form-row">
+                    <a className="form-label" href="javascript:;" onClick={()=>{navigate("/app/forgot-password")}}>Forgot your password?</a>
+                  </div>
+                  <div className="auth-button-bar">
+                    <Button variant="contained" type = "submit">Submit</Button>
+                  </div>
+                  {
+                    error
+                      ?<p className="err-msg">Incorrect username/password - please try again</p>
+                      :<p></p>
+                  }
+                </form>
+              </Box>
+            </CardContent>
+          </Card>
         </div>
       </div>
     );

--- a/stormpiper/stormpiper/spa/src/components/login.tsx
+++ b/stormpiper/stormpiper/spa/src/components/login.tsx
@@ -2,14 +2,21 @@ import React, { useState } from "react";
 import { useNavigate } from "react-router-dom"
 import { useForm } from "react-hook-form";
 // import "./login.css"
-import { Box, Card, CardContent, Typography } from "@material-ui/core";
+import { Box, Card, CardContent, makeStyles, Typography } from "@material-ui/core";
 import { TextField,Input,Button } from '@material-ui/core'
+
+const useStyles = makeStyles((theme)=>({
+  errorMsg:{
+    color:theme.palette.warning.main,
+    margin:'5px 20px'
+  }
+}))
 
 export default function Login(){
     const navigate = useNavigate()
     const {register,handleSubmit, getValues} = useForm()
     const [error,setError] = useState(false)
-
+    const classes = useStyles()
     const fields:{fieldID:string,label:string,type:string,required:boolean,value:string|number}[] = [
       {
         fieldID:'username',
@@ -82,9 +89,7 @@ export default function Login(){
                     <Button variant="contained" type = "submit">Submit</Button>
                   </div>
                   {
-                    error
-                      ?<p className="err-msg">Incorrect username/password - please try again</p>
-                      :<p></p>
+                    error && <Typography variant='caption' className={classes.errorMsg} align='center'>Incorrect username/password - please try again</Typography>
                   }
                 </form>
               </Box>

--- a/stormpiper/stormpiper/spa/src/components/map.jsx
+++ b/stormpiper/stormpiper/spa/src/components/map.jsx
@@ -1,7 +1,7 @@
 import DeckGL from "@deck.gl/react";
 import {FlyToInterpolator} from "deck.gl"
 import StaticMap from "react-map-gl";
-// import getTooltipContents from "./tooltip.jsx";
+import getTooltipContents from "./tooltip.jsx";
 import { useLocation } from "react-router-dom";
 import { useState,useEffect } from "react";
 
@@ -72,12 +72,15 @@ function DeckGLMap(props) {
       //   setCurrentZoom(state.viewState.zoom)
       // }}
       // onload={()=>checkFeature(props)}
-      // getTooltip={(object) => {
-      //   // if(object?.object){console.log('Selected Object',object)}
-      //   return object.object && {
-      //     html: getTooltipContents(object.object, object?.layer?.id,object?.layer?.props?.label),
-      //   };
-      // }}
+      getTooltip={(object) => {
+        if(object?.object){console.log('Selected Object',object)}
+        return object.object && {
+          html: getTooltipContents(object.object, object?.layer?.id,object?.layer?.props?.label),
+          style:{
+            borderRadius:'6px',
+          }
+        };
+      }}
     >
       <StaticMap mapboxApiAccessToken={MAPBOX_ACCESS_TOKEN} />
     </DeckGL>

--- a/stormpiper/stormpiper/spa/src/components/register.tsx
+++ b/stormpiper/stormpiper/spa/src/components/register.tsx
@@ -2,10 +2,14 @@ import React, { useState } from "react";
 import { useNavigate } from "react-router-dom"
 import { useForm } from "react-hook-form";
 import "./register.css"
-import { Box, Card, CardContent, Typography } from "@material-ui/core";
-import { TextField,Button } from '@material-ui/core'
+import { Box, Card, CardContent, Typography,makeStyles,TextField,Button} from "@material-ui/core";
 
-
+const useStyles = makeStyles((theme)=>({
+  errorMsg:{
+    color:theme.palette.warning.main,
+    margin:'5px 20px'
+  }
+}))
 
 export default function Register(){
     const navigate = useNavigate()
@@ -13,6 +17,7 @@ export default function Register(){
     const [error,setError] = useState(false)
     const [success,setSuccess] = useState(false)
     const [displayVerify,setDisplayVerify] = useState(false)
+    const classes = useStyles()
 
     const fields:{name:string,label:string,type:string,required?:boolean,defaultValue:string|number, minLength?:{value:number,message:string},maxLength?:{value:number,message:string},validate?:(val:any)=>boolean|string}[] = [
       {
@@ -112,10 +117,10 @@ export default function Register(){
                   <Button variant="contained" type = "submit">Submit</Button>
                 </div>
                 {
-                  error && <p className="err-msg">User already exists</p>
+                  error && <Typography variant='caption' className={classes.errorMsg} align='center'>User already exists</Typography>
                 }
                 {
-                  success && <p className="success-msg">Successfully registered - Check your email for a confirmation link, and return to <a href="javascript:;" onClick={()=>navigate('/app/login')}>Login</a></p>
+                  success && <Typography variant='caption' className={classes.errorMsg} align='center'>Successfully registered - Check your email for a confirmation link, and return to <a href="javascript:;" onClick={()=>navigate('/app/login')}>Login</a></Typography>
                 }
               </form>
             </Box>

--- a/stormpiper/stormpiper/spa/src/components/register.tsx
+++ b/stormpiper/stormpiper/spa/src/components/register.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import { useNavigate } from "react-router-dom"
 import { useForm } from "react-hook-form";
 import "./register.css"
-import { Typography } from "@material-ui/core";
+import { Box, Card, CardContent, Typography } from "@material-ui/core";
 import { TextField,Button } from '@material-ui/core'
 
 
@@ -62,7 +62,6 @@ export default function Register(){
                     {
                         <TextField  {...register(formField.name,{...formField})} label = {formField.label} type = {formField.type} required={formField.required}/>
                     }
-                    {/* <input className="form-input" {...register(formField.name,{...formField})} type={formField.type}/> */}
                     {errors[formField.name] && <p className="form-label error-msg">{errors[formField.name]?.message}</p>}
                 </div>
             )
@@ -101,26 +100,27 @@ export default function Register(){
 
 
     return (
-      <div className="login-container">
-        <div className="login-form">
-          <div className="login-form-body flex-column">
-            <Typography className="login-header" variant="subtitle1"> Enter Your New Account Information</Typography>
-            <form className="flex-column" onSubmit={handleSubmit(_handleSubmit)}>
-              {_renderFormFields()}
-              {/* <div className="button-bar">
-                <input className="submit-btn" type="submit" />
-              </div> */}
-              <div className="login-button-bar">
-                <Button variant="contained" type = "submit">Submit</Button>
-              </div>
-              {
-                error && <p className="err-msg">User already exists</p>
-              }
-              {
-                success && <p className="success-msg">Successfully registered - Check your email for a confirmation link, and return to <a href="javascript:;" onClick={()=>navigate('/app/login')}>Login</a></p>
-              }
-            </form>
-          </div>
+      <div className="flex-row">
+        <div className="flex lg-margin">
+          <Card>
+            <CardContent>
+            <Typography align="center" variant="subtitle1"> Enter Your New Account Information</Typography>
+            <Box sx={{margin:'1em'}}>
+              <form className="flex-column" onSubmit={handleSubmit(_handleSubmit)}>
+                {_renderFormFields()}
+                <div className="auth-button-bar">
+                  <Button variant="contained" type = "submit">Submit</Button>
+                </div>
+                {
+                  error && <p className="err-msg">User already exists</p>
+                }
+                {
+                  success && <p className="success-msg">Successfully registered - Check your email for a confirmation link, and return to <a href="javascript:;" onClick={()=>navigate('/app/login')}>Login</a></p>
+                }
+              </form>
+            </Box>
+            </CardContent>
+          </Card>
         </div>
       </div>
     );

--- a/stormpiper/stormpiper/spa/src/components/reset.tsx
+++ b/stormpiper/stormpiper/spa/src/components/reset.tsx
@@ -1,36 +1,44 @@
-import React, { useState } from "react";
-import { useNavigate,useParams } from "react-router-dom"
+import React, { useEffect, useState } from "react";
+import { useNavigate,useSearchParams } from "react-router-dom"
 import { useForm } from "react-hook-form";
 // import "./reset.css"
-import { Typography } from "@material-ui/core";
+import { Typography,TextField,Card, CardContent,Button, Box } from "@material-ui/core";
+import { textAlign } from "@mui/system";
 
 export default function Reset(){
     const navigate = useNavigate()
     const {register,handleSubmit,formState: { errors },getValues} = useForm()
     const [error,setError] = useState(false)
-    const params = useParams()
+    const [success,setSuccess] = useState(false)
+    const [resetContents,setResetContents] = useState((
+      <React.Fragment>
+          <Typography variant="subtitle1">
+            Checking your reset link...
+          </Typography>
+        </React.Fragment>
+    ))
+    const [searchParams, setSearchParams] = useSearchParams()
+
+    let expiresAt:string|null = searchParams.get('expires_at')
+    let now = new Date()
+    let expiryDateFormatted = new Date(expiresAt)
+
+    console.log("Expiry date: ",expiryDateFormatted)
 
     const fields: {
       name: string;
       label: string;
       type: string;
       required?: boolean;
-      defaultValue: string | number | undefined;
+      defaultValue: string | number | null;
       minLength?: { value: number; message: string };
       maxLength?: { value: number; message: string };
       validate?: (val: any) => boolean | string;
       display?: boolean;
     }[] = [
       {
-        name: "username",
-        label: "username",
-        type: "email",
-        required: true,
-        defaultValue: "",
-      },
-      {
         name: "password",
-        label: "password",
+        label: "New Password",
         type: "password",
         defaultValue: "",
         minLength: {
@@ -38,6 +46,7 @@ export default function Reset(){
           message: "Password must be longer than 8 characters",
         },
         required: true,
+        display:true,
       },
       {
         name: "confirm_password",
@@ -47,78 +56,100 @@ export default function Reset(){
         defaultValue: "",
         validate: (val) =>
           val === getValues("password") || "Passwords don't match",
+          display:true,
       },
       {
         name: "token",
         label: "Reset token",
         type: "string",
         required: true,
-        defaultValue: params.token,
+        defaultValue: searchParams.get("token"),
         display:false,
       }
     ];
-  
-      function _renderFormFields(){
-        let fieldDiv = Object.values(fields).map((formField:{name:string,label:string,type:string,required?:boolean,defaultValue:string|number|undefined})=>{
-            return (
-                  <div className="login-form-row">
-                      {formField.required
-                        ?<label className="form-label required" htmlFor={formField.name}>{formField.label}</label>
-                        :<label className="form-label" htmlFor={formField.name}>{formField.label}</label>
-                      }
-                      <input className="form-input" {...register(formField.name,{...formField})} type={formField.type}/>
-                      {errors[formField.name] && <p className="form-label error-msg">{errors[formField.name]?.message}</p>}
-                  </div>
-              )
-          })
-          return fieldDiv;
-        
-    }
+
+    function _renderFormFields(){
+      console.log("Rendering fields. Any errors?:",errors)
+      let fieldDiv = Object.values(fields).map((formField)=>{
+        return (
+              <div className="flex-column auth-form-row">
+                  {
+                      <TextField  {...register(formField.name,{...formField})} label = {formField.display?formField.label:null} type = {formField.display?formField.type:"hidden"} defaultValue={formField.defaultValue} required={formField.required}/>
+                  }
+                  {errors[formField.name] && <p className="form-label error-msg">{errors[formField.name]?.message}</p>}
+
+              </div>
+          )
+      })
+      return fieldDiv;
+
+}
 
     async function _handleSubmit(data:any,e:any){
         console.log("Event: ",e)
           const formData = new FormData(e.target);
+          console.log("formData: ",formData)
           const response = await fetch('/auth/reset-password', {
               credentials: "same-origin",
               method: "POST",
               headers:{
+                Accept:"application/json",
                 "Content-Type":"application/json"
               },
-              body: formData,
+              body: JSON.stringify(Object.fromEntries(formData.entries())),
             }).then((resp) => {
               if (resp.status == 200) {
-                console.log("redirect on success");
-                window.location.href = '/app/login';
                 setError(false)
+                setSuccess(true)
               } else {
                 console.warn("reset failure", resp);
                 setError(true)
+                setSuccess(false)
               }
             });
           return response
       }
-  
-  
 
     return (
-        <div className="reset-container">
-          <div className="reset-form">
-            <div className="reset-form-body">
-              <Typography className="reset-header" variant="subtitle1"> Welcome to the Tacoma Watershed Insights Tool</Typography>
-              <Typography className="reset-sub-header" variant="subtitle2"> reset or <a href="javascript:;" onClick={()=>navigate('/app/register')}>Register</a> to get Started</Typography>
-              <form onSubmit={handleSubmit(_handleSubmit)}>
-                {_renderFormFields()}
-                <div className="button-bar">
-                  <input className="submit-btn" type="submit" />
-                </div>
-                {
-                  error
-                    ?<p className="err-msg">Something went wrong - please try again</p>
-                    :<p></p>
-                }
-              </form>
-            </div>
-          </div>
+      <div className="flex-row">
+        <div className="flex lg-margin">
+          <Card>
+            <CardContent>
+              {
+                now>expiryDateFormatted
+                  ?(<React.Fragment>
+                    <Typography variant="subtitle1">
+                        Sorry, your password reset link has expired
+                      </Typography>
+                      <Typography variant="subtitle2">
+                        Please return to <a href="javascript:;" onClick={()=>navigate('/app/login')}>login </a> to request another link
+                      </Typography>
+                    </React.Fragment>)
+                  :(
+                    <React.Fragment>
+                      <Typography align="center" variant="subtitle1"> Welcome to the Tacoma Watershed Insights Tool</Typography>
+                      <Typography align = "center" variant="subtitle2"> Enter your new password below</Typography>
+                      <Box sx={{margin:'1em'}}>
+                        <form className = "flex" onSubmit={handleSubmit(_handleSubmit)}>
+                          {_renderFormFields()}
+                          <div className="auth-button-bar flex-column">
+                            <Button variant="contained" type="submit">Submit</Button>
+                          </div>
+                          {
+                            error &&
+                            <p className="err-msg">Something went wrong - please try again</p>
+                          }
+                          {
+                            success && <p className="success-msg">Your password was reset successfully. Please return to <a href="javascript:;" onClick={()=>navigate('/app/login')}>login</a></p>
+                          }
+                        </form>
+                      </Box>
+                    </React.Fragment>
+                  )
+              }
+            </CardContent>
+          </Card>
         </div>
-      );
+      </div>
+  );
 }

--- a/stormpiper/stormpiper/spa/src/components/reset.tsx
+++ b/stormpiper/stormpiper/spa/src/components/reset.tsx
@@ -1,9 +1,14 @@
 import React, { useEffect, useState } from "react";
 import { useNavigate,useSearchParams } from "react-router-dom"
 import { useForm } from "react-hook-form";
-// import "./reset.css"
-import { Typography,TextField,Card, CardContent,Button, Box } from "@material-ui/core";
-import { textAlign } from "@mui/system";
+import { Typography,TextField,Card, CardContent,Button, Box, makeStyles } from "@material-ui/core";
+
+const useStyles = makeStyles((theme)=>({
+  errorMsg:{
+    color:theme.palette.warning.main,
+    margin:'5px 20px'
+  }
+}))
 
 export default function Reset(){
     const navigate = useNavigate()
@@ -18,6 +23,8 @@ export default function Reset(){
         </React.Fragment>
     ))
     const [searchParams, setSearchParams] = useSearchParams()
+    const classes = useStyles()
+
 
     let expiresAt:string|null = searchParams.get('expires_at')
     let now = new Date()
@@ -76,7 +83,7 @@ export default function Reset(){
                   {
                       <TextField  {...register(formField.name,{...formField})} label = {formField.display?formField.label:null} type = {formField.display?formField.type:"hidden"} defaultValue={formField.defaultValue} required={formField.required}/>
                   }
-                  {errors[formField.name] && <p className="form-label error-msg">{errors[formField.name]?.message}</p>}
+                  {errors[formField.name] && <Typography variant='caption' className={classes.errorMsg} align='center'>{errors[formField.name]?.message}</Typography>}
 
               </div>
           )
@@ -134,14 +141,14 @@ export default function Reset(){
                           {_renderFormFields()}
                           <div className="auth-button-bar flex-column">
                             <Button variant="contained" type="submit">Submit</Button>
+                            {
+                              error &&
+                              <Typography variant='caption' className={classes.errorMsg} align='center'>Password reset failed. Please return to <a href="javascript:;" onClick={()=>navigate('/app/login')}>login and request a new reset link</a></Typography>
+                            }
+                            {
+                              success && <Typography variant='caption' className={classes.errorMsg} align='center'>Your password was reset successfully. Please return to <a href="javascript:;" onClick={()=>navigate('/app/login')}>login</a></Typography>
+                            }
                           </div>
-                          {
-                            error &&
-                            <p className="err-msg">Something went wrong - please try again</p>
-                          }
-                          {
-                            success && <p className="success-msg">Your password was reset successfully. Please return to <a href="javascript:;" onClick={()=>navigate('/app/login')}>login</a></p>
-                          }
                         </form>
                       </Box>
                     </React.Fragment>

--- a/stormpiper/stormpiper/spa/src/components/tooltip.jsx
+++ b/stormpiper/stormpiper/spa/src/components/tooltip.jsx
@@ -1,8 +1,9 @@
 // DeckGL react component
 const fieldDict = {
-    activeSWMain:['ALTID','DIAMETER','INSTALLDATE'],
-    activeSWFacility:['ALTID','SUBBASIN','FACILITYDETAIL','MEDIATYPE'],
-    default:['OBJECTID']
+    activeSWMain:['altid','diameter'],
+    activeSWFacility:['altid','subbasin','facilitytype'],
+    tmnt_delineations:['altid','relid'],
+    default:['altid']
 }
 
 
@@ -11,16 +12,15 @@ function getTooltipContents(object,layer,label) {
     const feat = object
     const fields = fieldDict[layer]?fieldDict[layer]:fieldDict.default
     if (feat){
-        return (
-            `<h4> Layer: ${label}</h4>
-            ${fields.map(field=>{
-                return(`<h5> ${field}: ${feat?.properties[field]}</h5>`)    
-            })}`
-        );
+        let content = `<h4> Layer: ${label}</h4>
+        ${fields.reduce((acc,field,i) => {
+          return acc + `<p>${field}: ${feat?.properties[field]}</p>`;
+        },"")}`;
+        return content;
     }
-   
+
   }
 
-  
-  
+
+
   export default getTooltipContents; //`<Tooltip feat={${object} layer={${object?.layer?.id}}}></Tooltip>`

--- a/stormpiper/stormpiper/spa/src/components/verify.tsx
+++ b/stormpiper/stormpiper/spa/src/components/verify.tsx
@@ -48,10 +48,10 @@ export default function Verify(){
           if(resp.status===200){
             setVerifyResults(
               <React.Fragment>
-                <Typography variant="subtitle1">
+                <Typography variant="subtitle1" align="center">
                   Thank you for verifying your email with Tacoma Watershed Insights
                 </Typography>
-                <Typography variant="subtitle2">
+                <Typography variant="subtitle2" align="center">
                   Please <a href="javascript:;" onClick={()=>navigate('/app/login')}>log in </a> with the credentials you created for your account
                 </Typography>
               </React.Fragment>
@@ -59,10 +59,10 @@ export default function Verify(){
           }else{
             setVerifyResults(
             <React.Fragment>
-            <Typography variant="subtitle1">
+            <Typography variant="subtitle1" align="center">
               Sorry, something went wrong with your verification
             </Typography>
-            <Typography variant="subtitle2">
+            <Typography variant="subtitle2" align="center">
               Please <a href="javascript:;" onClick={()=>navigate('/app/login')}>log in </a> again to request another link
             </Typography>
           </React.Fragment>

--- a/stormpiper/stormpiper/spa/src/index.jsx
+++ b/stormpiper/stormpiper/spa/src/index.jsx
@@ -4,8 +4,10 @@ import { BrowserRouter, Routes, Route } from "react-router-dom";
 import "./index.css";
 import App from "./App";
 import Login from "./components/login"
+import Reset from "./components/reset"
 import Register from "./components/register"
 import Verify from "./components/verify";
+import Forgot from "./components/forgot"
 // import reportWebVitals from './reportWebVitals';
 
 ReactDOM.render(
@@ -16,6 +18,8 @@ ReactDOM.render(
         <Route path="/app/login/" element={<Login/>}></Route>
         <Route path="/app/register/" element={<Register/>}></Route>
         <Route path="/app/verify/" element={<Verify/>}></Route>
+        <Route path="/app/reset/" element={<Reset/>}></Route>
+        <Route path="/app/forgot-password/" element={<Forgot/>}></Route>
         <Route path="/app/map/" element={<App/>}>
           <Route path="tmnt" element={<App/>}>
             <Route path=":id" element = {<App/>}></Route>


### PR DESCRIPTION
We now have have an `app/forgot` and `app/reset` route that will handle password reset token requests and password reset submissions.

`app/reset` assumes that the password reset link sent by the backend will include a token and expires_at url param, similar to the `app/verify` route.

There are also some minor css improvements here, and a tooltip feature to display basic stats about features that the user hovers over.

@austinorr Sorry the diff is probably larger than you would like - you only really need to look at forgot.tsx and reset.tsx