### PR TITLE
Fix scenario and bmp inventory form behavior

### DIFF
--- a/stormpiper/stormpiper/spa/src/components/bmp-detail-page/bmp-detail-form.jsx
+++ b/stormpiper/stormpiper/spa/src/components/bmp-detail-page/bmp-detail-form.jsx
@@ -160,6 +160,17 @@ export function BMPDetailForm() {
     return errorList;
   }
 
+  function facilityChangeHandler(newFacilityType) {
+    setFacilityType(newFacilityType);
+  }
+
+  function formChangeHandler(data) {
+    Object.keys(data).forEach(
+      (k) => (data[k] = data[k] === "" ? null : data[k])
+    );
+    setTMNTAttrs(data);
+  }
+
   function renderForm() {
     if (loadingState) {
       return <p>loading...</p>;
@@ -193,7 +204,8 @@ export function BMPDetailForm() {
             values={TMNTAttrs}
             allFacilities={specs.context}
             currentFacility={facilityType}
-            facilityChangeHandler={setFacilityType}
+            facilityChangeHandler={facilityChangeHandler}
+            formDataEmitter={formChangeHandler}
             handleFormSubmit={_handleSubmit}
             handleEditReset={removeEdits}
           ></BMPForm>

--- a/stormpiper/stormpiper/spa/src/components/bmpForm.tsx
+++ b/stormpiper/stormpiper/spa/src/components/bmpForm.tsx
@@ -214,7 +214,6 @@ export const BMPForm = forwardRef(function BMPForm(props: formProps, ref) {
     isCostField: boolean
   ) {
     if (getValues(fieldID)) {
-      // console.log(`Retaining ${fieldID} value of ${getValues(fieldID)}`);
       return getValues(fieldID);
     }
     const fallbackDefault: any =
@@ -222,12 +221,6 @@ export const BMPForm = forwardRef(function BMPForm(props: formProps, ref) {
     const defaultValue: any = fieldObj.default || fallbackDefault;
 
     if (props.values) {
-      // console.log(
-      //   `Resetting ${fieldID} value to r${
-      //     props.values[fieldID] || defaultValue
-      //   }`
-      // );
-
       return props.values[fieldID] || defaultValue;
     }
   }
@@ -240,9 +233,6 @@ export const BMPForm = forwardRef(function BMPForm(props: formProps, ref) {
     let defaultValues: {
       [x: string]: string | number | boolean | null | undefined;
     } = {};
-    // simpleStatus
-    //   ? (fieldSet = props.simpleFields)
-    //   : (fieldSet = props.allFields);
     fieldSet = props.allFields;
     Object.keys(fieldSet.properties).map((k) => {
       if (k === "node_id") {

--- a/stormpiper/stormpiper/spa/src/components/bmpForm.tsx
+++ b/stormpiper/stormpiper/spa/src/components/bmpForm.tsx
@@ -390,6 +390,7 @@ export const BMPForm = forwardRef(function BMPForm(props: formProps, ref) {
                   formDisabled //having showSubmit disabled the field is a workaround to disable it only in the scenario version of this form
                 }
                 onClick={() => setIsTouched(true)}
+                onFocus={(e) => e.target.select()}
               />
             )}
             {errors[formField.fieldID] && (

--- a/stormpiper/stormpiper/spa/src/components/scenario-module/scenario-bmp-detail-form.jsx
+++ b/stormpiper/stormpiper/spa/src/components/scenario-module/scenario-bmp-detail-form.jsx
@@ -93,13 +93,6 @@ export const ScenarioBMPForm = forwardRef(function ScenarioBMPForm(
     Object.keys(data).forEach(
       (k) => (data[k] = data[k] === "" ? null : data[k])
     );
-    if (
-      facilityType.match("_simple") &&
-      !data["facility_type"].match("_simple")
-    ) {
-      data["facility_type"] = data["facility_type"] + "_simple";
-    }
-
     facilitySetter({
       type: "FeatureCollection",
       features: [
@@ -158,6 +151,10 @@ export const ScenarioBMPForm = forwardRef(function ScenarioBMPForm(
     _handleSubmit(data, facility);
   }
 
+  function facilityChangeHandler(newFacilityType) {
+    setFacilityType(newFacilityType);
+  }
+
   function renderForm() {
     if (loadingState) {
       return <p>loading...</p>;
@@ -202,8 +199,7 @@ export const ScenarioBMPForm = forwardRef(function ScenarioBMPForm(
             }
             allFacilities={specs.context}
             currentFacility={facilityType}
-            facilityChangeHandler={setFacilityType}
-            handleFormSubmit={_handleSubmit}
+            facilityChangeHandler={facilityChangeHandler}
             ref={childRef}
             showSubmit={false}
             formDataEmitter={formOnChangeHandler}


### PR DESCRIPTION
This fixes issues where toggling between simple/non-simple in the bmp inventory form would reset the facility type to the previously saved value, and where scenario facility updates were not getting submitted properly.

@austinorr please feel free to pull this down and test